### PR TITLE
fix bag regex_replace

### DIFF
--- a/src/EditFiles.cpp
+++ b/src/EditFiles.cpp
@@ -7,7 +7,7 @@ auto replaceByTemplates(const string &line, const std::shared_ptr<std::map<std::
     -> string {
     string tmpString = line;
     for (auto it = templates->cbegin(); it != templates->end(); ++it) {
-        tmpString = regex_replace(line, std::regex{it->first}, it->second);
+        tmpString = regex_replace(tmpString, std::regex{it->first}, it->second);
     }
 
     return tmpString;
@@ -23,7 +23,9 @@ void editFileByTemplates(const string &&filePath, const std::shared_ptr<std::map
         line = replaceByTemplates(line, patterns);
         outFileStream << line << '\n';
     }
-
+    outFileStream.close();
+    searchFileStream.close();
+    
     std::filesystem::remove(filePath);
     std::filesystem::rename(outputFilePath, filePath);
 }


### PR DESCRIPTION
regex_replace(line, std::regex{it->first}, it->second);  -> regex_replace(tmpString, std::regex{it->first}, it->second);

```.toml
[templates]
"COLOR" = "BLACK"
"NAME" = "NAME2222"
```

Problem: if there were several templates, then only the last one was executed
___________________________
line = COLOR

on the first pass:
tmpString = BLACK

on the first pass:
tmpString = COLOR

return tmpString
__________________________


Without closing the files, an exception was thrown